### PR TITLE
Default to `ring`

### DIFF
--- a/impl-rustls/Cargo.toml
+++ b/impl-rustls/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 travis-ci = { repository = "https://github.com/edgedb/rust-tls-api/", branch = "master" }
 
 [dependencies]
-rustls       = { version = "0.23.5" }
+rustls       = { version = "0.23.5", default-features = false, features = ["ring"] }
 webpki       = "0.22.0"
 webpki-roots = "0.26.1"
 tokio        = { version = "1.2.0", features = [], optional = true }

--- a/impl-rustls/src/connector.rs
+++ b/impl-rustls/src/connector.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use rustls::crypto::aws_lc_rs;
+use rustls::crypto::ring;
 use rustls::crypto::verify_tls12_signature;
 use rustls::crypto::verify_tls13_signature;
 use rustls::crypto::WebPkiSupportedAlgorithms;
@@ -87,7 +87,7 @@ impl tls_api::TlsConnectorBuilder for TlsConnectorBuilder {
             }
 
             let no_cert_verifier = NoCertificateServerVerifier {
-                supported: aws_lc_rs::default_provider().signature_verification_algorithms,
+                supported: ring::default_provider().signature_verification_algorithms,
             };
 
             self.config


### PR DESCRIPTION
It seems edgedb-tokio didn't yet switch to `aws-lc-rs`. I agree it's harder to build, in that it fails with current nix darwin `Security` framework.

Right now, `aws-lc-rs` is accidentally included by edgedb-tokio through default features in `rustls>=0.23` which is pulled by this crate. This is PR hardcodes ring, but I think a proper solution are features flag, if you agree?